### PR TITLE
Fixed small markup error

### DIFF
--- a/_posts/2015-01-22-ie78-friendly-nth-child.md
+++ b/_posts/2015-01-22-ie78-friendly-nth-child.md
@@ -54,7 +54,7 @@ With this method you can also select the 3rd, 4th, &#8230; `li`.
 }</code></pre>
 
 This would select the 3rd `li` inside the `ul`.  
-Sadly that workaround doesn&#8217;t help with the more advanced CSS3 selectors like `nth-child(2n)`, `:nth-child(2n+5) or the aforementioned <code>:last-child`</code>.
+Sadly that workaround doesn&#8217;t help with the more advanced CSS3 selectors like `nth-child(2n)`, `:nth-child(2n+5)` or the aforementioned `:last-child`.
 
 As always I&#8217;ve put that code together in a [CodePen][1] so you can try it out:
 


### PR DESCRIPTION
I'm not sure why the diff is so all over the place. I just fixed this:

![screen shot 2015-04-10 at 13 18 39](https://cloud.githubusercontent.com/assets/2098462/7086679/1d50e012-df84-11e4-8cbc-ce0d40afbcd1.png)
